### PR TITLE
Implement ignorehtml param

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ php composer.phar require "igorakaamigo/php5-tiny-bbcode"
 use \Igorakaamigo\Utils\BBCode;
 
 echo BBCode::convert('[b]A bold string[/b]');
+// Outputs: <strong>A bold string</strong>
+
+echo BBCode::convert('<span>A text</span>');
+// Outputs: &lt;span&gt;A text&lt;/span&gt;
+
+echo BBCode::convert('[i]Hi&nbsp;there![/i]');
+// Outputs: <em>Hi&amp;nbsp;there!</em>
+
+echo BBCode::convert('[i]Hi&nbsp;there<br>!!![/i]', ['&nbsp;', '<br>']);
+// Outputs: <em>Hi&nbsp;there<br>!!!</em>
 ```
 
 ### Supported BBCodes

--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -60,14 +60,22 @@ class BBCode
      * BBCode translation
      *
      * @param string $sourceString A string containing BBCode tags
+     * @param array $ignoreHtml do not remove these html tags / entities, default value is []
      * @return string HTML string
      */
-    static function convert($sourceString)
+    static function convert($sourceString, $ignoreHtml = [])
     {
-        return preg_replace(
-            array_keys(self::$_patterns),
-            array_values(self::$_patterns),
-            htmlentities($sourceString)
-        );
+        $processedIgnoreHtml = array_map(function ($e) {
+            return htmlentities($e);
+        }, $ignoreHtml);
+
+        $result = preg_replace(array_keys(self::$_patterns), array_values(self::$_patterns),
+            htmlentities($sourceString));
+
+        if (count($ignoreHtml) > 0) {
+            $result = strtr($result, array_combine($processedIgnoreHtml, $ignoreHtml));
+        }
+
+        return $result;
     }
 }

--- a/tests/BBCodeTest.php
+++ b/tests/BBCodeTest.php
@@ -222,4 +222,17 @@ final class BBCodeTest extends PHPUnit_Framework_TestCase
             return "<span style=\"color: #AABBCC;\">$v</span>";
         });
     }
+
+    public function testItShouldDealWithIgnoreHtmlParam() {
+        $expected = "A leading string &nbsp;&quot;<br><br/><br /> A trailing string";
+        $source = 'A leading string &nbsp;&quot;<br><br/><br /> A trailing string';
+        $ignoreHtml = array(
+            '&nbsp;',
+            '&quot;',
+            '<br>',
+            '<br/>',
+            '<br />',
+        );
+        $this->assertEquals($expected, BBCode::convert($source, $ignoreHtml));
+    }
 }


### PR DESCRIPTION
Instead of implementing extensions to add entities/tags like &nbsp; or <br>, the $ignoreHtml param added to BBCode::convert()
#4 