### PR TITLE
Charset param added to convert()

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ echo BBCode::convert('[i]Hi&nbsp;there![/i]');
 
 echo BBCode::convert('[i]Hi&nbsp;there<br>!!![/i]', ['&nbsp;', '<br>']);
 // Outputs: <em>Hi&nbsp;there<br>!!!</em>
+
+/**
+ * Sometimes, when the PHP is not properly configured,
+ * as a result of a htmlspecialchars() call, convert() can
+ * break non-ansi symbols. For those cases you can
+ * explicitly specify the correct charset.
+ */
+echo BBCode::convert('[b]Windows-1251 string: Кириллица[/b]', [], 'cp1251');
+// Outputs: <strong>Windows-1251 string: Кириллица</strong>
 ```
 
 ### Supported BBCodes

--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -63,14 +63,17 @@ class BBCode
      * @param array $ignoreHtml do not remove these html tags / entities, default value is []
      * @return string HTML string
      */
-    static function convert($sourceString, $ignoreHtml = [])
+    static function convert($sourceString, $ignoreHtml = [], $charset = 'UTF-8')
     {
-        $processedIgnoreHtml = array_map(function ($e) {
-            return htmlentities($e);
+        $processedIgnoreHtml = array_map(function ($e) use ($charset) {
+            return htmlspecialchars($e, ENT_COMPAT, $charset);
         }, $ignoreHtml);
 
-        $result = preg_replace(array_keys(self::$_patterns), array_values(self::$_patterns),
-            htmlentities($sourceString));
+        $result = preg_replace(
+            array_keys(self::$_patterns),
+            array_values(self::$_patterns),
+            htmlspecialchars($sourceString, ENT_COMPAT, $charset)
+        );
 
         if (count($ignoreHtml) > 0) {
             $result = strtr($result, array_combine($processedIgnoreHtml, $ignoreHtml));

--- a/tests/BBCodeTest.php
+++ b/tests/BBCodeTest.php
@@ -235,4 +235,30 @@ final class BBCodeTest extends PHPUnit_Framework_TestCase
         );
         $this->assertEquals($expected, BBCode::convert($source, $ignoreHtml));
     }
+
+    public function testItShouldDealWithStringCharset() {
+        $expected = iconv('utf-8', 'cp1251', 'A leading string  Абв A trailing string');
+        $source = iconv('utf-8', 'cp1251', 'A leading string  Абв A trailing string');
+        $this->assertEquals($expected, BBCode::convert($source, [], 'cp1251'), 'Windows-1251 charset tes failed');
+
+        $expected = '';
+        $source = iconv('utf-8', 'cp1251', 'A leading string  Абв A trailing string');
+        $this->assertEquals($expected, BBCode::convert($source, [], 'utf-8'), 'Wrong charset test failed');
+
+        $expected = 'A leading string  Юникод A trailing string';
+        $source = 'A leading string  Юникод A trailing string';
+        $this->assertEquals($expected, BBCode::convert($source, []), 'Default charset test failed');
+
+        $expected = iconv('utf-8', 'cp1251', 'A leading string  &Абв; A trailing string');
+        $source = iconv('utf-8', 'cp1251', 'A leading string  &Абв; A trailing string');
+        $this->assertEquals($expected, BBCode::convert($source, [iconv('utf-8', 'cp1251', '&Абв;')], 'cp1251'), 'ignoreHtml: Windows-1251 charset tes failed');
+
+        $expected = '';
+        $source = iconv('utf-8', 'cp1251', 'A leading string  &Абв; A trailing string');
+        $this->assertEquals($expected, BBCode::convert($source, [iconv('utf-8', 'cp1251', '&Абв;')], 'utf-8'), 'ignoreHtml: Wrong charset test failed');
+
+        $expected = 'A leading string  &Абв; A trailing string';
+        $source = 'A leading string  &Абв; A trailing string';
+        $this->assertEquals($expected, BBCode::convert($source, ['&Абв;']), 'ignoreHtml: Default charset test failed');
+    }
 }


### PR DESCRIPTION
#7 
There is no reason for me to add htmlspecialchars internals (flags) to convert, so I'll add the charset param only.