### PR TITLE
htmlspecialchars() calls dropped; charset param of convert() dropped too

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,6 @@ echo BBCode::convert('[i]Hi&nbsp;there![/i]');
 
 echo BBCode::convert('[i]Hi&nbsp;there<br>!!![/i]', ['&nbsp;', '<br>']);
 // Outputs: <em>Hi&nbsp;there<br>!!!</em>
-
-/**
- * Sometimes, when the PHP is not properly configured,
- * as a result of a htmlspecialchars() call, convert() can
- * break non-ansi symbols. For those cases you can
- * explicitly specify the correct charset.
- */
-echo BBCode::convert('[b]Windows-1251 string: Кириллица[/b]', [], 'cp1251');
-// Outputs: <strong>Windows-1251 string: Кириллица</strong>
 ```
 
 ### Supported BBCodes

--- a/src/BBCode.php
+++ b/src/BBCode.php
@@ -34,6 +34,14 @@ namespace Igorakaamigo\Utils;
  */
 class BBCode
 {
+    private static $_specialchars = [
+        '#&#'  => '&amp;',
+        '#"#'  => '&quot;',
+        '#\'#' => '&#039;',
+        '#<#'  => '&lt;',
+        '#>#'  => '&gt;',
+    ];
+
     private static $_patterns = [
         '#\[b\](.*?)\[/b\]#si'                            => '<strong>\1</strong>',
         '#\[i\](.*?)\[/i\]#si'                            => '<em>\1</em>',
@@ -63,22 +71,34 @@ class BBCode
      * @param array $ignoreHtml do not remove these html tags / entities, default value is []
      * @return string HTML string
      */
-    static function convert($sourceString, $ignoreHtml = [], $charset = 'UTF-8')
+    static function convert($sourceString, $ignoreHtml = [])
     {
-        $processedIgnoreHtml = array_map(function ($e) use ($charset) {
-            return htmlspecialchars($e, ENT_COMPAT, $charset);
+        $processedIgnoreHtml = array_map(function ($e) {
+            return self::_htmlspecialchars($e);
         }, $ignoreHtml);
 
         $result = preg_replace(
             array_keys(self::$_patterns),
             array_values(self::$_patterns),
-            htmlspecialchars($sourceString, ENT_COMPAT, $charset)
+            self::_htmlspecialchars($sourceString)
         );
 
         if (count($ignoreHtml) > 0) {
-            $result = strtr($result, array_combine($processedIgnoreHtml, $ignoreHtml));
+            $result = strtr(
+                $result,
+                array_combine($processedIgnoreHtml, $ignoreHtml)
+            );
         }
 
         return $result;
+    }
+
+    private static function _htmlspecialchars($str)
+    {
+        return preg_replace(
+            array_keys(self::$_specialchars),
+            array_values(self::$_specialchars),
+            $str
+        );
     }
 }

--- a/tests/BBCodeTest.php
+++ b/tests/BBCodeTest.php
@@ -236,29 +236,9 @@ final class BBCodeTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($expected, BBCode::convert($source, $ignoreHtml));
     }
 
-    public function testItShouldDealWithStringCharset() {
-        $expected = iconv('utf-8', 'cp1251', 'A leading string  Абв A trailing string');
-        $source = iconv('utf-8', 'cp1251', 'A leading string  Абв A trailing string');
-        $this->assertEquals($expected, BBCode::convert($source, [], 'cp1251'), 'Windows-1251 charset tes failed');
-
-        $expected = '';
-        $source = iconv('utf-8', 'cp1251', 'A leading string  Абв A trailing string');
-        $this->assertEquals($expected, BBCode::convert($source, [], 'utf-8'), 'Wrong charset test failed');
-
-        $expected = 'A leading string  Юникод A trailing string';
-        $source = 'A leading string  Юникод A trailing string';
-        $this->assertEquals($expected, BBCode::convert($source, []), 'Default charset test failed');
-
-        $expected = iconv('utf-8', 'cp1251', 'A leading string  &Абв; A trailing string');
-        $source = iconv('utf-8', 'cp1251', 'A leading string  &Абв; A trailing string');
-        $this->assertEquals($expected, BBCode::convert($source, [iconv('utf-8', 'cp1251', '&Абв;')], 'cp1251'), 'ignoreHtml: Windows-1251 charset tes failed');
-
-        $expected = '';
-        $source = iconv('utf-8', 'cp1251', 'A leading string  &Абв; A trailing string');
-        $this->assertEquals($expected, BBCode::convert($source, [iconv('utf-8', 'cp1251', '&Абв;')], 'utf-8'), 'ignoreHtml: Wrong charset test failed');
-
-        $expected = 'A leading string  &Абв; A trailing string';
-        $source = 'A leading string  &Абв; A trailing string';
-        $this->assertEquals($expected, BBCode::convert($source, ['&Абв;']), 'ignoreHtml: Default charset test failed');
+    public function testItShouldNotBreakSingleByteCharsetString() {
+        $expected = iconv('utf-8', 'cp1251', 'Строка&amp;nbsp;со <спецсимволами>');
+        $source = iconv('utf-8', 'cp1251', 'Строка&nbsp;со <спецсимволами>');
+        $this->assertEquals($expected, BBCode::convert($source, [iconv('utf-8', 'cp1251', '<спецсимволами>')]));
     }
 }


### PR DESCRIPTION
#7 
#9 
#10 
#11 

We're not using htmlspecialchars() anymore, so we dont need its parameters to be passed through convert() call.